### PR TITLE
fix: drop hyprland-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -427,7 +427,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -535,7 +535,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -567,6 +567,8 @@ dependencies = [
  "gtk4",
  "log",
  "nix",
+ "serde",
+ "serde_json",
  "swayipc",
 ]
 
@@ -824,9 +826,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -834,29 +836,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -932,6 +934,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "system-deps"
 version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +980,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1071,7 +1084,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1105,7 +1118,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1116,7 +1129,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,28 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,12 +93,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-rs"
@@ -235,48 +207,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -344,16 +278,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -641,7 +565,6 @@ dependencies = [
  "clap",
  "flexi_logger",
  "gtk4",
- "hyprland",
  "log",
  "nix",
  "swayipc",
@@ -658,33 +581,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hyprland"
-version = "0.4.0-beta.3"
-source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#1c789fe0ed1baa2fb14b98ed47e9aef8e5acdd74"
-dependencies = [
- "async-stream",
- "derive_more",
- "either",
- "futures-lite",
- "hyprland-macros",
- "pastey",
- "serde",
- "serde_json",
- "serde_repr",
- "tokio",
-]
-
-[[package]]
-name = "hyprland-macros"
-version = "0.4.0-beta.3"
-source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#1c789fe0ed1baa2fb14b98ed47e9aef8e5acdd74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -772,17 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,12 +732,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pin-project-lite"
@@ -987,17 +866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,16 +891,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "strsim"
@@ -1113,32 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,18 +1028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,12 +1038,6 @@ name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,8 +571,10 @@ dependencies = [
  "clap",
  "flexi_logger",
  "gtk4",
+ "indoc",
  "log",
  "nix",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "swayipc",
@@ -616,6 +624,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -746,6 +763,16 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1173,6 +1200,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 flexi_logger = "0.31.9"
 gtk4 = "0.10.3"
-# hyprland = "0.4.0-beta.3"
-# Use master branch, which allows me to access pid of layers
-hyprland = { git = "https://github.com/hyprland-community/hyprland-rs", branch = "master" }
 log = "0.4.30"
 nix = { version = "0.31.3", features = ["signal"] }
 swayipc = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ nix = { version = "0.31.3", features = ["signal"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 swayipc = "4.0.0"
+
+[dev-dependencies]
+indoc = "2.0.7"
+pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ flexi_logger = "0.31.9"
 gtk4 = "0.10.3"
 log = "0.4.30"
 nix = { version = "0.31.3", features = ["signal"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 swayipc = "4.0.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,18 +26,13 @@ impl AppState {
         let existing_clients = self.clients.clone();
         let open_clients = self.backend.open_clients()?;
 
-        self.clients.extend(
-            open_clients
-                .iter()
-                .filter(|c| {
-                    // Filter out gtkshutdown so the app doesn't kill itself
-                    c.app_id() != APP_ID
-                        && !existing_clients
-                            .iter()
-                            .any(|existing| existing.pid() == c.pid())
-                })
-                .cloned(),
-        );
+        self.clients.extend(open_clients.into_iter().filter(|c| {
+            // Filter out gtkshutdown so the app doesn't kill itself
+            c.app_id() != APP_ID
+                && !existing_clients
+                    .iter()
+                    .any(|existing| existing.pid() == c.pid())
+        }));
 
         Ok(())
     }

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -1,18 +1,148 @@
-use hyprland::{
-    data::{Clients, Layers},
-    dispatch::{Dispatch, DispatchType, WindowIdentifier},
-    error::HyprError,
-    shared::HyprData,
+use std::{
+    collections::HashMap,
+    env,
+    io::{Read, Write},
+    os::unix::net::UnixStream,
+    path::Path,
 };
 
-use crate::client_killer::{Client, WaylandBackend};
+use anyhow::Context;
+use nix::unistd::Pid;
+use serde::Deserialize;
+
+use crate::client_killer::{Client, ClientKind, KillStatus, WaylandBackend};
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+struct HyprlandWindowClient {
+    pid: i32,
+    class: String,
+    title: String,
+}
+
+impl From<HyprlandWindowClient> for Client {
+    fn from(value: HyprlandWindowClient) -> Self {
+        Self {
+            pid: Pid::from_raw(value.pid),
+            app_id: value.class,
+            title: Some(value.title),
+            kind: ClientKind::Window,
+            status: KillStatus::Alive,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Monitor {
+    levels: HashMap<String, Vec<HyprlandLayerClient>>,
+}
+
+#[derive(serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+struct HyprlandLayerClient {
+    pid: i32,
+    namespace: String,
+}
+
+impl From<HyprlandLayerClient> for Client {
+    fn from(value: HyprlandLayerClient) -> Self {
+        Self {
+            pid: Pid::from_raw(value.pid),
+            app_id: value.namespace,
+            title: None,
+            kind: ClientKind::Layer,
+            status: KillStatus::Alive,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct HyprlandStatus {
+    #[serde(rename = "configProvider")]
+    config_provider: String,
+}
+
+impl HyprlandStatus {
+    fn is_using_lua(&self) -> bool {
+        match self.config_provider.as_str() {
+            "lua" => true,
+            _ => false, // very in-depth checks i know
+        }
+    }
+}
 
 #[derive(Clone)]
-pub(super) struct HyprlandBackend {}
+pub(super) struct HyprlandBackend {
+    is_using_lua: bool,
+}
+
+impl HyprlandBackend {
+    pub(super) fn new() -> anyhow::Result<Self> {
+        let status = Self::status()?;
+        let is_using_lua = status.is_using_lua();
+
+        Ok(Self { is_using_lua })
+    }
+
+    /// Returns the result of `hyprctl status`.
+    fn status() -> anyhow::Result<HyprlandStatus> {
+        let response = Self::send_ipc_request("j/status")?;
+        Ok(serde_json::from_str::<HyprlandStatus>(&response)
+            .expect("IPC status JSON should be successfully deserialized"))
+    }
+
+    /// Constructs and returns a stream connection to the hyprland socket. This
+    /// method assumes that `HYPRLAND_INSTANCE_SIGNATURE` and `XDG_RUNTIME_DIR`
+    /// exists at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// - Socket connection was unsuccessful
+    fn ipc_stream() -> anyhow::Result<UnixStream> {
+        let xdg_runtime_dir = env::var("XDG_RUNTIME_DIR").expect("XDG_RUNTIME_DIR should exist");
+        let hyprland_instance_signature = env::var("HYPRLAND_INSTANCE_SIGNATURE")
+            .expect("HYPRLAND_INSTANCE_SIGNATURE should exist");
+        let socket_path =
+            format!("{xdg_runtime_dir}/hypr/{hyprland_instance_signature}/.socket.sock");
+        let socket = Path::new(&socket_path);
+        UnixStream::connect(socket).context("unable to connect to hyprland IPC socket")
+    }
+
+    fn send_ipc_request(request: &str) -> anyhow::Result<String> {
+        let mut stream = Self::ipc_stream()?;
+        stream.write_all(request.as_bytes())?;
+        stream.shutdown(std::net::Shutdown::Write)?;
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response)?;
+
+        Ok(response)
+    }
+
+    fn open_windows() -> anyhow::Result<Vec<HyprlandWindowClient>> {
+        let response = Self::send_ipc_request("j/clients")?;
+        Ok(serde_json::from_str::<Vec<HyprlandWindowClient>>(&response)
+            .expect("IPC windows response JSON should be successfully deserialized"))
+    }
+
+    fn open_layers() -> anyhow::Result<Vec<HyprlandLayerClient>> {
+        let response = Self::send_ipc_request("j/layers")?;
+        Ok(Self::deserialize_layers_json(&response))
+    }
+
+    fn deserialize_layers_json(json: &str) -> Vec<HyprlandLayerClient> {
+        serde_json::from_str::<HashMap<String, Monitor>>(json)
+            .expect("IPC layers response JSON should be successfully deserialized")
+            .into_values()
+            .flat_map(|m| m.levels.into_values())
+            .flatten()
+            .collect()
+    }
+}
 
 impl WaylandBackend for HyprlandBackend {
     fn open_clients(&self) -> anyhow::Result<Vec<Client>> {
-        let windows = Clients::get()?;
+        let windows = Self::open_windows()?;
         let windows = windows
             .iter()
             .filter(|c| {
@@ -22,11 +152,9 @@ impl WaylandBackend for HyprlandBackend {
             .cloned()
             .map(Client::from);
 
-        let layers = Layers::get()?;
+        let layers = Self::open_layers()?;
         let layers = layers
             .iter()
-            .flat_map(|(_, display)| display.iter())
-            .flat_map(|(_, layers)| layers.iter())
             .filter(|c| c.pid > 0)
             .cloned()
             .map(Client::from);

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -99,7 +99,9 @@ impl HyprlandBackend {
     ///
     /// - Socket connection was unsuccessful
     fn ipc_stream() -> anyhow::Result<UnixStream> {
-        let xdg_runtime_dir = env::var("XDG_RUNTIME_DIR").expect("XDG_RUNTIME_DIR should exist");
+        let xdg_runtime_dir = env::var("XDG_RUNTIME_DIR")
+            .or_else(|_| std::env::var("UID").map(|uid| format!("/run/user/{uid}")))
+            .expect("UID should exist");
         let hyprland_instance_signature = env::var("HYPRLAND_INSTANCE_SIGNATURE")
             .expect("HYPRLAND_INSTANCE_SIGNATURE should exist");
         let socket_path =

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -63,10 +63,7 @@ struct HyprlandStatus {
 
 impl HyprlandStatus {
     fn is_using_lua(&self) -> bool {
-        match self.config_provider.as_str() {
-            "lua" => true,
-            _ => false, // very in-depth checks i know
-        }
+        self.config_provider.as_str() == "lua"
     }
 }
 

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use nix::unistd::Pid;
 use serde::Deserialize;
 
@@ -124,6 +124,9 @@ impl HyprlandBackend {
         let mut response = String::new();
         stream.read_to_string(&mut response)?;
 
+        if response.contains("error") || response.contains("unknown request") {
+            bail!(response)
+        }
         Ok(response)
     }
 

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -333,7 +333,8 @@ mod tests {
 
         pretty_assertions::assert_eq!(monitors, expected);
 
-        let layers = HyprlandBackend::deserialize_layers_json(json);
+        let mut layers = HyprlandBackend::deserialize_layers_json(json);
+        layers.sort_by_key(|c| (c.pid, c.namespace.clone()));
         let expected = vec![
             expected_client.clone(),
             expected_client.clone(),

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -166,45 +166,178 @@ impl WaylandBackend for HyprlandBackend {
         Ok(clients)
     }
 
-    fn gracefully_close(&self, client: &super::Client) -> anyhow::Result<()> {
-        let hyprlang_dispatch =
-            DispatchType::CloseWindow(WindowIdentifier::ProcessId(client.pid().as_raw() as u32));
+    fn gracefully_close(&self, client: &Client) -> anyhow::Result<()> {
+        let pid = client.pid();
+        let cmd = if self.is_using_lua {
+            format!("dispatch hl.dsp.window.close({{ window = \"pid:{pid}\" }})")
+        } else {
+            format!("dispatch closewindow pid:{pid}")
+        };
+        Self::send_ipc_request(&cmd)?;
+        Ok(())
+    }
+}
 
-        let lua_args = format!(
-            r#"hl.dsp.window.close({{ window = "pid:{}" }})"#,
-            client.pid().as_raw()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn deserialize_window_client() {
+        let json = indoc! {r#"
+            [{
+                "floating": false,
+                "monitor": 1,
+                "class": "window",
+                "title": "~",
+                "initialClass": "window",
+                "initialTitle": "window",
+                "pid": 3441,
+                "xwayland": false,
+                "pinned": false,
+                "pinFullscreened": false,
+                "fullscreen": 0,
+                "fullscreenClient": 0,
+                "fullscreenHandler": "scrolling",
+                "allowedOverFullscreen": false,
+                "grouped": [],
+                "tags": [],
+                "swallowing": "0x0",
+                "focusHistoryID": 1,
+                "inhibitingIdle": false,
+                "xdgTag": "",
+                "xdgDescription": "",
+                "contentType": "none",
+                "tearingHint": false,
+                "stableId": "1800001b"
+            }]
+        "#};
+        let client = serde_json::from_str::<Vec<HyprlandWindowClient>>(json)
+            .expect("test JSON should be successfully deserialized");
+        let expected = vec![HyprlandWindowClient {
+            pid: 3441,
+            title: String::from("~"),
+            class: String::from("window"),
+        }];
+
+        pretty_assertions::assert_eq!(client, expected);
+    }
+
+    #[test]
+    fn deserialize_layer_clients() {
+        let json = indoc! {r#"
+            {
+            "monitor_1": {
+                "levels": {
+                    "0": [
+                            {
+                                "address": "0x6071d7158a90",
+                                "x": 1920,
+                                "y": 0,
+                                "w": 1920,
+                                "h": 1080,
+                                "alpha": 1,
+                                "namespace": "layer",
+                                "pid": 3442
+                            }
+                    ],
+                    "1": [
+            ],
+                    "2": [
+                            {
+                                "address": "0x6071d7150a30",
+                                "x": 1920,
+                                "y": 0,
+                                "w": 1920,
+                                "h": 48,
+                                "alpha": 1,
+                                "namespace": "layer",
+                                "pid": 3442
+                            }
+                    ],
+                    "3": [
+            ]
+                }
+            },"monitor_2": {
+                "levels": {
+
+                    "0": [
+                            {
+                                "address": "0x6071d717c2f0",
+                                "x": 0,
+                                "y": 0,
+                                "w": 1920,
+                                "h": 1080,
+                                "alpha": 1,
+                                "namespace": "layer",
+                                "pid": 3442
+                            }
+                    ],
+                    "1": [
+            ],
+                    "2": [
+                            {
+                                "address": "0x6071d715b0b0",
+                                "x": 0,
+                                "y": 0,
+                                "w": 1920,
+                                "h": 48,
+                                "alpha": 0,
+                                "namespace": "layer",
+                                "pid": 3442
+                            }
+                    ],
+                    "3": [
+            ]
+                }
+            }
+            }
+        "#};
+        let monitors = serde_json::from_str::<HashMap<String, Monitor>>(json)
+            .expect("test JSON should be successfully deserialized");
+
+        let expected_client = HyprlandLayerClient {
+            pid: 3442,
+            namespace: String::from("layer"),
+        };
+
+        let mut monitor_1_levels = HashMap::new();
+        monitor_1_levels.insert(String::from("0"), vec![expected_client.clone()]);
+        monitor_1_levels.insert(String::from("1"), vec![]);
+        monitor_1_levels.insert(String::from("2"), vec![expected_client.clone()]);
+        monitor_1_levels.insert(String::from("3"), vec![]);
+
+        let mut monitor_2_levels = HashMap::new();
+        monitor_2_levels.insert(String::from("0"), vec![expected_client.clone()]);
+        monitor_2_levels.insert(String::from("1"), vec![]);
+        monitor_2_levels.insert(String::from("2"), vec![expected_client.clone()]);
+        monitor_2_levels.insert(String::from("3"), vec![]);
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            String::from("monitor_1"),
+            Monitor {
+                levels: monitor_1_levels,
+            },
+        );
+        expected.insert(
+            String::from("monitor_2"),
+            Monitor {
+                levels: monitor_2_levels,
+            },
         );
 
-        // Equivalent of calling `hyprctl dispatch closewindow pid:<PID>`
-        match Dispatch::call(hyprlang_dispatch) {
-            Ok(_) => Ok(()),
-            // If this happens, assume that the user is using hyprland lua
-            Err(HyprError::NotOkDispatch(_)) => {
-                log::debug!("Running: hyprctl dispatch {lua_args}");
+        pretty_assertions::assert_eq!(monitors, expected);
 
-                // Run hyprctl dispatch manually, since hyprland-rs doesn't support lua as of now
-                let output = std::process::Command::new("hyprctl")
-                    .args(["dispatch", &lua_args])
-                    .output()?;
+        let layers = HyprlandBackend::deserialize_layers_json(json);
+        let expected = vec![
+            expected_client.clone(),
+            expected_client.clone(),
+            expected_client.clone(),
+            expected_client,
+        ];
 
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stdout = String::from_utf8_lossy(&output.stdout);
-
-                if !output.status.success() {
-                    log::error!(
-                        "hyprctl dispatch failed (status {}): stdout={stdout} stderr={stderr}",
-                        output.status
-                    );
-                } else {
-                    log::debug!(
-                        "hyprctl dispatch succeeded (status {}): stdout={stdout} stderr={stderr}",
-                        output.status
-                    );
-                }
-
-                Ok(())
-            }
-            Err(e) => Err(e.into()),
-        }
+        pretty_assertions::assert_eq!(layers, expected);
     }
 }

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -152,20 +152,15 @@ impl WaylandBackend for HyprlandBackend {
     fn open_clients(&self) -> anyhow::Result<Vec<Client>> {
         let windows = Self::open_windows()?;
         let windows = windows
-            .iter()
+            .into_iter()
             .filter(|c| {
                 // Skip negative PIDs to avoid nuking entire session
                 c.pid > 0
             })
-            .cloned()
             .map(Client::from);
 
         let layers = Self::open_layers()?;
-        let layers = layers
-            .iter()
-            .filter(|c| c.pid > 0)
-            .cloned()
-            .map(Client::from);
+        let layers = layers.into_iter().filter(|c| c.pid > 0).map(Client::from);
 
         let mut clients = windows.chain(layers).collect::<Vec<Client>>();
         clients.sort();

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -4,6 +4,7 @@ use std::{
     io::{Read, Write},
     os::unix::net::UnixStream,
     path::Path,
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -111,7 +112,12 @@ impl HyprlandBackend {
     }
 
     fn send_ipc_request(request: &str) -> anyhow::Result<String> {
+        let timeout = Duration::from_secs(2);
+
         let mut stream = Self::ipc_stream()?;
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+
         stream.write_all(request.as_bytes())?;
         stream.shutdown(std::net::Shutdown::Write)?;
 

--- a/src/client_killer/mod.rs
+++ b/src/client_killer/mod.rs
@@ -8,7 +8,6 @@ use std::{
 
 use anyhow::Context;
 
-use ::hyprland::data::LayerClient;
 use nix::{
     sys::signal::{Signal, kill},
     unistd::Pid,
@@ -181,30 +180,6 @@ impl Ord for Client {
     }
 }
 
-impl From<::hyprland::data::Client> for Client {
-    fn from(value: ::hyprland::data::Client) -> Self {
-        Self {
-            pid: Pid::from_raw(value.pid),
-            title: Some(value.title.to_owned()),
-            app_id: value.class.to_owned(),
-            kind: ClientKind::Window,
-            status: KillStatus::Alive,
-        }
-    }
-}
-
-impl From<LayerClient> for Client {
-    fn from(value: LayerClient) -> Self {
-        Self {
-            pid: Pid::from_raw(value.pid),
-            title: None,                        // Layers do not have titles
-            app_id: value.namespace.to_owned(), // Layer namespace is close enough to an app ID
-            kind: ClientKind::Layer,
-            status: KillStatus::Alive,
-        }
-    }
-}
-
 impl Client {
     pub fn pid(&self) -> &Pid {
         &self.pid
@@ -262,7 +237,12 @@ pub fn detect_backend() -> Option<Box<dyn WaylandBackend>> {
 
     if let Ok(current_desktop) = &std::env::var("XDG_CURRENT_DESKTOP") {
         match current_desktop.as_str() {
-            HYPRLAND_STRING => return Some(Box::new(HyprlandBackend {})),
+            HYPRLAND_STRING => {
+                return Some(Box::new(
+                    HyprlandBackend::new()
+                        .expect("hyprland backend should be successfully initialized"),
+                ));
+            }
             SWAY_STRING => return Some(Box::new(SwayBackend {})),
             _ => return None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,12 @@ impl Args {
         if let Some(post_cmd) = &self.post_cmd {
             let post_cmd = post_cmd.split_whitespace().collect::<Vec<&str>>();
 
-            let command = post_cmd.first().context("Unable to parse --post_cmd.")?;
+            let command = post_cmd
+                .first()
+                .context("Unable to parse --post_cmd.")?
+                .to_owned();
 
-            let args = post_cmd.iter().skip(1).cloned().collect::<Vec<&str>>();
+            let args = post_cmd.into_iter().skip(1).collect::<Vec<&str>>();
 
             std::process::Command::new(command)
                 .args(args)


### PR DESCRIPTION
hyprland-rs is not being properly maintained currently (see https://github.com/hyprland-community/hyprland-rs/issues/391), so it is best to interface with hyprland's IPC socket instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hyprland window detection and handling through direct IPC communication.
  * Added support for both standard and Lua-based window-closing commands.
  * Filtered invalid window processes and removed duplicate entries.
  * Improved reliability when initializing Hyprland integration.
  * Improved post-command handling for commands with arguments.
  * Reduced unnecessary processing when refreshing the list of open clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->