### PR TITLE
feat: add sway support

### DIFF
--- a/nix/dev/vms/common.nix
+++ b/nix/dev/vms/common.nix
@@ -53,6 +53,12 @@ in {
 
     # Enable Bash to ensure environment variables are set.
     programs.bash.enable = true;
+
+    # Enable waybar for testing layer client teardown
+    programs.waybar = {
+      enable = true;
+      systemd.enable = true;
+    };
   };
 
   virtualisation.vmVariant.virtualisation = {

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(mut backend: Box<dyn WaylandBackend>) -> anyhow::Result<Self> {
+    pub fn new(backend: Box<dyn WaylandBackend>) -> anyhow::Result<Self> {
         let clients = backend.open_clients()?;
 
         Ok(Self {

--- a/src/client_killer/hyprland.rs
+++ b/src/client_killer/hyprland.rs
@@ -151,7 +151,7 @@ impl HyprlandBackend {
 }
 
 impl WaylandBackend for HyprlandBackend {
-    fn open_clients(&mut self) -> anyhow::Result<Vec<Client>> {
+    fn open_clients(&self) -> anyhow::Result<Vec<Client>> {
         let windows = Self::open_windows()?;
         let windows = windows.into_iter().map(Client::from);
 

--- a/src/client_killer/mod.rs
+++ b/src/client_killer/mod.rs
@@ -166,7 +166,7 @@ impl Client {
 
 pub trait WaylandBackend {
     /// Retrieves all currently-open clients.
-    fn open_clients(&mut self) -> anyhow::Result<Vec<Client>>;
+    fn open_clients(&self) -> anyhow::Result<Vec<Client>>;
 
     /// Meant to be used first before sending SIGTERM (and eventually SIGKILL)
     /// signal, so apps have a chance to gracefully exit.

--- a/src/client_killer/sway.rs
+++ b/src/client_killer/sway.rs
@@ -1,3 +1,5 @@
+use std::{cell::RefCell};
+
 use anyhow::bail;
 use nix::unistd::Pid;
 use swayipc::{Connection, Node, NodeType};
@@ -98,21 +100,22 @@ impl RootNode {
 }
 
 pub(super) struct SwayBackend {
-    connection: Connection,
+    connection: RefCell<Connection>,
 }
 
 impl SwayBackend {
     pub(super) fn new() -> anyhow::Result<Self> {
-        let connection = Connection::new()?;
+        let connection = RefCell::new(Connection::new()?);
         Ok(Self { connection })
     }
 }
 
 impl WaylandBackend for SwayBackend {
-    fn open_clients(&mut self) -> anyhow::Result<Vec<Client>> {
-        let root = RootNode::try_from(self.connection.get_tree()?)?;
+    fn open_clients(&self) -> anyhow::Result<Vec<Client>> {
+        let root = RootNode::try_from(self.connection.borrow_mut().get_tree()?)?;
 
-        // TODO: Also return layers
+        // Sway doesn't expose layer information, so this just returns window
+        // client types instead
         Ok(root.clients().into_iter().map(Client::from).collect())
     }
 

--- a/src/client_killer/sway.rs
+++ b/src/client_killer/sway.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell};
+use std::cell::RefCell;
 
 use anyhow::bail;
 use nix::unistd::Pid;
@@ -120,7 +120,9 @@ impl WaylandBackend for SwayBackend {
     }
 
     fn gracefully_close(&self, client: &super::Client) -> anyhow::Result<()> {
-        todo!()
+        let cmd = format!(r#"[pid={}] kill"#, client.pid());
+        self.connection.borrow_mut().run_command(cmd)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- **feat: extract clients from sway tree**
- **chore: update flake lock**
- **fix: include fixtures**
- **chore: pin home-manager state version**
- **fix: only run prettier on specific files**
- **chore: add checks**
- **chore: add PR workflow**
- **chore: add waybar for layer shutdown testing**
- **feat: implement gracefully_close for sway backend**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Sway session handling by enabling graceful closure of targeted client windows.
  - Improved client detection and enumeration for Sway environments.
  - Updated backend access behavior for more reliable window management across supported Wayland compositors.

- **Testing**
  - Enabled Waybar in virtual machine test environments, including its system service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->